### PR TITLE
Remove reference to Google Reader from readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ A better way to tell the world when your blog is updated.
 
 ## Description ##
 
-This plugin is a simple way to let people know in real-time when your blog is updated.  PubSubHubbub/WebSub is widely adopted and is used by Google Reader, Google Alerts and many other services.  Subscription requests are relayed through hubs, which validate and verify the request. Hubs then distribute new and updated content to subscribers when it becomes available.
+This plugin is a simple way to let people know in real-time when your blog is updated.  PubSubHubbub/WebSub is widely adopted and is used by Google Alerts and many other services.  Subscription requests are relayed through hubs, which validate and verify the request. Hubs then distribute new and updated content to subscribers when it becomes available.
 
 This plugin:
 


### PR DESCRIPTION
Present tense reference to Google Reader (RIP 2013 😢) makes the plugin's homepage seem as if it's stuck in a timewarp. Perhaps it could be replaced with more up to date examples?