### PR TITLE
Add proper content-type headers "application/x-www-form-urlencoded" to hub updates

### DIFF
--- a/includes/class-pubsubhubbub-publisher.php
+++ b/includes/class-pubsubhubbub-publisher.php
@@ -79,7 +79,7 @@ class PubSubHubbub_Publisher {
 			'redirection' => 20,
 			'user-agent' => "$user_agent; PubSubHubbub/WebSub",
 			'headers' => array(
-				'content-type' => 'application/x-www-form-urlencoded;charset=UTF-8'
+				'content-type' => 'application/x-www-form-urlencoded'
 			),
 			'body' => $post_string,
 		);

--- a/includes/class-pubsubhubbub-publisher.php
+++ b/includes/class-pubsubhubbub-publisher.php
@@ -78,6 +78,9 @@ class PubSubHubbub_Publisher {
 			'limit_response_size' => 1048576,
 			'redirection' => 20,
 			'user-agent' => "$user_agent; PubSubHubbub/WebSub",
+			'headers' => array(
+				'content-type' => 'application/x-www-form-urlencoded'
+			),
 			'body' => $post_string,
 		);
 

--- a/includes/class-pubsubhubbub-publisher.php
+++ b/includes/class-pubsubhubbub-publisher.php
@@ -79,7 +79,7 @@ class PubSubHubbub_Publisher {
 			'redirection' => 20,
 			'user-agent' => "$user_agent; PubSubHubbub/WebSub",
 			'headers' => array(
-				'content-type' => 'application/x-www-form-urlencoded'
+				'content-type' => 'application/x-www-form-urlencoded;charset=UTF-8'
 			),
 			'body' => $post_string,
 		);


### PR DESCRIPTION
Add proper content-type headers "application/x-www-form-urlencoded" when sending updates to hubs, as shown in Google's documentation (https://pubsubhubbub.appspot.com/).