### PR TITLE
fix: empty option on fresh install leads to broken feed links

### DIFF
--- a/includes/class-pubsubhubbub-admin.php
+++ b/includes/class-pubsubhubbub-admin.php
@@ -49,6 +49,8 @@ class Pubsubhubbub_Admin {
 				},
 			)
 		);
+
+		add_option( 'pubsubhubbub_endpoints', "https://pubsubhubbub.appspot.com\nhttps://pubsubhubbub.superfeedr.com\nhttps://websubhub.com/hub" );
 	}
 
 	public static function add_help_tab() {

--- a/includes/class-pubsubhubbub-publisher.php
+++ b/includes/class-pubsubhubbub-publisher.php
@@ -117,7 +117,13 @@ class PubSubHubbub_Publisher {
 	 */
 	public static function get_hubs() {
 		$endpoints = get_option( 'pubsubhubbub_endpoints' );
-		$hub_urls  = explode( PHP_EOL, $endpoints );
+
+		// Fail with an empty array when option retrieval fails
+		if ( false === $endpoints ) {
+			$hub_urls = [];
+		} else {
+			$hub_urls = explode( PHP_EOL, $endpoints );
+		}
 
 		return apply_filters( 'pubsubhubbub_hub_urls', $hub_urls );
 	}


### PR DESCRIPTION
## Issue

On a fresh install the `pubsubhubbub_endpoints` option is not properly set up, therefore no default value is saved in the `wp_options` table. When retrieving the feed XML, plugin attempts to retrieve the options failing and trying to explode a `false` value. This leads to the hub urls variable to contain a single empty element, resulting in the feed returning the following markup:

```xml
<atom:link rel="hub" href=""/>
```

## Fix

This PR follows up the `register_setting` with an `add_option` call to actually set the default value, which only works if the option is not set—updating the field persists expected behaviour. An additional check is added to handle this case when option retrieval fails, avoiding an empty link and preferring none to be displayed instead.